### PR TITLE
Use Ctypes.{TYPE, FOREIGN} instead of Cstubs.{TYPE, FOREIGN}

### DIFF
--- a/lib_gen/sodium_bindings.ml
+++ b/lib_gen/sodium_bindings.ml
@@ -20,7 +20,7 @@ open Ctypes
 
 module Type = Sodium_types.C(Sodium_types_detected)
 
-module C(F: Cstubs.FOREIGN) = struct
+module C(F: Ctypes.FOREIGN) = struct
   let prefix = "sodium"
 
   let init    = F.(foreign (prefix^"_init")    (void @-> returning int))

--- a/lib_gen/sodium_types.ml
+++ b/lib_gen/sodium_types.ml
@@ -17,7 +17,7 @@
 
 module Static = Ctypes_static
 
-module C(F: Cstubs.Types.TYPE) = struct
+module C(F: Ctypes.TYPE) = struct
 
   module Gen_hash(M: sig
     val scope : string

--- a/sodium.opam
+++ b/sodium.opam
@@ -22,7 +22,7 @@ depends: [
   "base-bytes"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ctypes" {>= "0.6.0"}
+  "ctypes" {>= "0.13.0"}
   "ounit2" {with-test & >= "2.2.6"}
 ]
 depexts: [


### PR DESCRIPTION
In order to build ocaml-sodium with [ctypes >= 0.13.0](https://github.com/yallop/ocaml-ctypes/blob/master/CHANGES.md#ctypes-0130), we need to use `Ctypes.TYPE` and `Ctypes.FOREIGN` instead of `Cstubs.TYPE` and `Cstubs.FOREIGN`, respectively.