### PR TITLE
Use pkg-config to discover libsodium

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -1,0 +1,17 @@
+module C = Configurator.V1
+
+let () =
+  C.main ~name:"sodium" (fun c ->
+      let default : C.Pkg_config.package_conf =
+        { libs = [ "-lsodium" ]; cflags = [] }
+      in
+      let conf =
+        match C.Pkg_config.get c with
+        | None -> default
+        | Some pc -> (
+            match C.Pkg_config.query pc ~package:"libsodium" with
+            | None -> default
+            | Some deps -> deps)
+      in
+      C.Flags.write_sexp "c_flags.sexp" conf.cflags;
+      C.Flags.write_sexp "c_library_flags.sexp" conf.libs)

--- a/config/dune
+++ b/config/dune
@@ -1,0 +1,7 @@
+(executable
+  (name discover)
+  (libraries dune-configurator))
+
+(rule
+  (targets c_flags.sexp c_library_flags.sexp)
+  (action (run ./discover.exe)))

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
   (name sodium)
   (public_name sodium)
   (libraries ctypes sodium.storage sodium.generated)
-  (c_library_flags :standard -lsodium)
+  (c_library_flags (:include ../config/c_library_flags.sexp))
   (modules :standard \ sodium_storage))
 
 (library

--- a/lib_gen/dune
+++ b/lib_gen/dune
@@ -1,7 +1,8 @@
 (library
   (name sodium_generated)
   (public_name sodium.generated)
-  (c_library_flags :standard -lsodium)
+  (c_flags (:include ../config/c_flags.sexp))
+  (c_library_flags (:include ../config/c_library_flags.sexp))
   (libraries ctypes.stubs sodium_bindings)
   (modules sodium_generated)
   (c_names sodium_stubs))
@@ -38,7 +39,7 @@
 (rule
   (deps sodium_types_detect.c)
   (targets sodium_types_detect)
-  (action (bash "cc -I \"$(ocamlfind query ctypes)\" -I \"$(ocamlc -where)\" -o sodium_types_detect sodium_types_detect.c")))
+  (action (bash "cc -I \"$(ocamlfind query ctypes)\" -I \"$(ocamlc -where)\" $(pkg-config --cflags libsodium) -o sodium_types_detect sodium_types_detect.c")))
 
 (rule
   (deps sodium_types_detect)


### PR DESCRIPTION
Currently this library doesn't build unless libsodium is installed in the standard search paths for headers and dynamic libraries.

This PR uses pkg-config to find libsodium wherever it is installed according to pkg-config configuration.